### PR TITLE
fixed logger class

### DIFF
--- a/src/main/java/org/powertac/samplebroker/grpc/GrpcSocketAdapter.java
+++ b/src/main/java/org/powertac/samplebroker/grpc/GrpcSocketAdapter.java
@@ -26,7 +26,6 @@ import org.powertac.samplebroker.interfaces.Activatable;
 import org.powertac.samplebroker.interfaces.BrokerContext;
 import org.powertac.samplebroker.interfaces.Initializable;
 import org.powertac.samplebroker.interfaces.IpcAdapter;
-import org.powertac.samplebroker.r.CharStreamAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -38,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 public class GrpcSocketAdapter implements IpcAdapter, Initializable, Activatable
 {
 
-  static private Logger log = LogManager.getLogger(CharStreamAdapter.class);
+  static private Logger log = LogManager.getLogger(GrpcSocketAdapter.class);
 
   @Autowired
   private MessageDispatcher dispatcher;

--- a/src/main/java/org/powertac/samplebroker/grpc/ServerMessageStreamService.java
+++ b/src/main/java/org/powertac/samplebroker/grpc/ServerMessageStreamService.java
@@ -24,7 +24,6 @@ import org.powertac.samplebroker.grpc.ServerMessagesStreamGrpc;
 import org.powertac.samplebroker.grpc.XmlMessage;
 import org.powertac.samplebroker.core.MessageDispatcher;
 import org.powertac.samplebroker.interfaces.IpcAdapter;
-import org.powertac.samplebroker.r.CharStreamAdapter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -34,7 +33,7 @@ import java.util.LinkedList;
 public class ServerMessageStreamService extends ServerMessagesStreamGrpc.ServerMessagesStreamImplBase
 {
 
-  static private Logger log = LogManager.getLogger(CharStreamAdapter.class);
+  static private Logger log = LogManager.getLogger(ServerMessageStreamService .class);
 
   @Autowired
   private MessageDispatcher dispatcher;


### PR DESCRIPTION
Okay the Logger class is done. Next problem: The initialize call...

If I take the @Service away, we cannot use the "FindBean" solution that's currently employed. Alternatively, we don't make them initializable but instead keep the code in another method that we call manually on the IpcAdapter interface. Let me know what solution you think works best and I'll update the GrpcAdapter accordingly. Ideally we can keep the @Service tag but won't have our code triggered unless it's the chosen IpcAdapter which sounds a lot like an IpcAdapter interface update. 